### PR TITLE
Handle strings with escaped quotes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,19 +203,15 @@ impl<'i> Tokenizer<'i> {
             let begin = self.cursor;
 
             if self.peek_char() == Some(b'"') {
-                let first_char = self.next_char();
-                let mut backslash = first_char == Some(b'\\');
+                self.next_char()?;
                 loop {
-                    let nc = self.next_char()?;
-                    if nc == b'\\' {
-                        backslash = !backslash;
-                        continue;
-                    } else if backslash {
-                        backslash = false;
-                        continue;
-                    }
-                    if nc == b'"' {
-                        break;
+                    match self.next_char()? {
+                        b'\\' => {
+                            // ignore escpaed character
+                            self.next_char()?;
+                        }
+                        b'"' => break,
+                        _ => {}
                     }
                 }
             } else {


### PR DESCRIPTION
S-Expressions such as
```lisp
(code . "println!(\"Hello World!\");")
```
would fail to parse because the escaped strings internally was not handled.